### PR TITLE
Don't close drawer when there's an error on creation

### DIFF
--- a/src/components/Project/Secrets/index.js
+++ b/src/components/Project/Secrets/index.js
@@ -448,7 +448,7 @@ export default class Secrets extends React.Component {
               <AppBar position="static" color="default">
                   <Toolbar>
                     <Typography variant="title" color="inherit">
-                        Environment Variable
+                        Secret
                     </Typography>
                   </Toolbar>
               </AppBar>

--- a/src/components/Project/Secrets/index.js
+++ b/src/components/Project/Secrets/index.js
@@ -3,8 +3,6 @@ import Typography from 'material-ui/Typography';
 import Grid from 'material-ui/Grid';
 import Toolbar from 'material-ui/Toolbar';
 import Button from 'material-ui/Button';
-import Table, { TableCell, TableHead, TableBody, TableRow } from 'material-ui/Table';
-import Paper from 'material-ui/Paper';
 import Drawer from 'material-ui/Drawer';
 import AppBar from 'material-ui/AppBar';
 import Dialog, {
@@ -381,8 +379,6 @@ export default class Secrets extends React.Component {
         <Loading />
       )
     }
-
-    var self = this;
 
     return (
       <div>

--- a/src/components/Project/Secrets/index.js
+++ b/src/components/Project/Secrets/index.js
@@ -258,7 +258,7 @@ export default class Secrets extends React.Component {
 
   onError(form){
     // todo
-    this.closeDrawer(true)
+    this.setState({ saving: false })
   }
 
   onSuccess(form){

--- a/src/components/Utils/Pagination/index.js
+++ b/src/components/Utils/Pagination/index.js
@@ -1,10 +1,9 @@
 import React from 'react';
-import { TableRow, TableFooter } from 'material-ui/Table';
+import { TableRow } from 'material-ui/Table';
 import KeyboardArrowLeft from '@material-ui/icons/KeyboardArrowLeft';
 import KeyboardArrowRight from '@material-ui/icons/KeyboardArrowRight';
 import IconButton from '@material-ui/core/IconButton';
 
-import styles from './style.module.css';
 import Typography from 'material-ui/Typography';
 
 export default class Pagination extends React.Component {

--- a/src/components/Utils/Table/index.js
+++ b/src/components/Utils/Table/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import Grid from 'material-ui/Grid';
 import Paper from 'material-ui/Paper';
-import Table, { TableCell, TableHead, TableBody, TableRow, TableFooter } from 'material-ui/Table';
+import Table, { TableCell, TableHead, TableBody, TableRow } from 'material-ui/Table';
 import Typography from 'material-ui/Typography';
 import Toolbar from 'material-ui/Toolbar';
 import Pagination from '../Pagination';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Remove `this.closeDrawer()` when onError is called and set the SAVE button's `saving` state to false.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We don't want to close the drawer when there's validation errors for Secret creation.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [X] Locally
- [ ] Development Environment 


## Screenshots (if appropriate):


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

