### PR TITLE
Fix Stop Release Button

### DIFF
--- a/src/components/Project/Releases/index.js
+++ b/src/components/Project/Releases/index.js
@@ -479,7 +479,7 @@ export default class Releases extends React.Component {
   }
 
   stopReleaseButton(release) {
-    if (release.state !== "failed" || release.state !== "complete") {
+    if (release.state !== "failed" && release.state !== "complete") {
       return (
         <Button
         className={styles.drawerButton}

--- a/src/components/Project/Releases/index.js
+++ b/src/components/Project/Releases/index.js
@@ -479,7 +479,7 @@ export default class Releases extends React.Component {
   }
 
   stopReleaseButton(release) {
-    if (release.state !== "failed" && release.state !== "complete") {
+    if (release.state === "fetching" || release.state === "waiting") {
       return (
         <Button
         className={styles.drawerButton}


### PR DESCRIPTION
Describe the bug
The STOP RELEASE button always shows on previously stopped or failed releases. The button does nothing when clicked

Expected behavior
The button should either not be present, or deactivated

Resolution:
The button is deactivated when the release is in a 'failed' or 'completed' state. The only way it should be enabled if the release is in a 'waiting' state.

Fixes #183 