### PR TITLE
Display Canceled Releases

### DIFF
--- a/src/components/Admin/Projects/index.js
+++ b/src/components/Admin/Projects/index.js
@@ -491,50 +491,48 @@ export default class Projects extends React.Component {
                         let extensionStatuses = []
 
                         if(project.releases.entries.length > 0) {
-                          switch(project.releases.entries[0].state){
-                            case "complete":
-                              color = "green"
-                              break;
-                            case "waiting":
-                              color = "yellow"
-                              break;
-                            case "failed":
-                              color = "red"
-                              break;
-                            default:
-                              break;
-                          }
-
                           project.releases.entries[0].releaseExtensions.forEach(function(releaseExtension){
                             let status = "lightgray"
+                            let textColor = "white"
+
+                            console.log(releaseExtension.state)
                             switch(releaseExtension.state){
                               case "complete":
                                 status = "green"
                                 break;
-                              case "waiting":
-                                status = "yellow"
-                                break;
                               case "fetching":
+                              case "waiting":
+                              case "running":
                                 status = "yellow"
+                                textColor = "black"
                                 break;
                               case "failed":
                                 status = "red"
+                                break;
+                              case "canceled":
+                                status = "purple"
                                 break;
                               default:
                                 break;
                             }                            
                             extensionStatuses.push(
-                              <span key={releaseExtension.id} style={{ border: "2px solid black", margin: 4, backgroundColor: status, padding: 5, fontWeight: "normal" }}>
+                              <span key={releaseExtension.id} style={{ border: "2px solid black", margin: 4, backgroundColor: status, padding: 5, fontWeight: "normal", color: textColor }}>
                                 {releaseExtension.extension.extension.key}
                               </span>
                             )
                           })
+                        } else {
+                          extensionStatuses.push(
+                              <span key='no-releases' style={{ border: "2px solid black", margin: 4, backgroundColor: "black", padding: 5, fontWeight: "normal", color: "white" }}>
+                                No Releases
+                              </span>
+                            )
                         }
 
                         return (
-                          <div key={env.id + project.id} style={{ backgroundColor: color, padding: 10, border: "1px solid black", margin: 4, textAlign: "center", fontWeight: "bold" }}>
+                          <div key={env.id + project.id} style={{ backgroundColor: color, padding: 10, border: "1px solid black", margin: 4, textAlign: "left", fontWeight: "bold" }}>
                             <Link to={"/projects/" + project.slug + "/" + env.key}>
-                              {env.name + "(" + env.key + ")"} &nbsp;
+                              {env.name} &nbsp;
                             </Link>
                             {extensionStatuses}
                           </div>

--- a/src/components/Admin/Projects/index.js
+++ b/src/components/Admin/Projects/index.js
@@ -495,7 +495,6 @@ export default class Projects extends React.Component {
                             let status = "lightgray"
                             let textColor = "white"
 
-                            console.log(releaseExtension.state)
                             switch(releaseExtension.state){
                               case "complete":
                                 status = "green"

--- a/src/components/Project/Releases/index.js
+++ b/src/components/Project/Releases/index.js
@@ -14,6 +14,7 @@ import Grid from 'material-ui/Grid';
 import DoubleRightIcon from 'react-icons/lib/fa/angle-double-right';
 import ExtensionStateCompleteIcon from 'material-ui-icons/CheckCircle';
 import ExtensionStateFailedIcon from 'material-ui-icons/Error';
+import ExtensionStateCanceledIcon from 'material-ui-icons/Fingerprint';
 import Loading from 'components/Utils/Loading';
 import { graphql } from 'react-apollo';
 import gql from 'graphql-tag';
@@ -61,6 +62,8 @@ class ReleaseView extends React.Component {
               return (<Chip label={release.releaseExtensions[i].extension.extension.name} style={{ backgroundColor: "green", color: "white", marginRight: 4 }} />)
             case "failed":
               return (<Chip label={release.releaseExtensions[i].extension.extension.name} style={{ backgroundColor: "red", color: "white", marginRight: 4 }} />)               
+            case "canceled":
+              return (<Chip label={release.releaseExtensions[i].extension.extension.name} style={{ backgroundColor: "purple", color: "white", marginRight: 4 }} />)               
             default:
               return (<Chip label={release.releaseExtensions[i].extension.extension.name} style={{ backgroundColor: "yellow", color: "black", marginRight: 4 }} />)
           }
@@ -86,6 +89,9 @@ class ReleaseView extends React.Component {
       break;
       case "running":
         state = (<CircularProgress className={styles.progress} color="secondary" />)
+      break;
+      case "canceled":
+        state = (<Chip label="CANCELED" style={{ backgroundColor: "purple", color: "white" }} />)
       break;
       case "failed":
         state = (<Chip label="FAILED" style={{ backgroundColor: "red", color: "white" }} />)
@@ -359,6 +365,9 @@ export default class Releases extends React.Component {
           }
           if(release.releaseExtensions[i].state === "failed"){
               stateIcon = <ExtensionStateFailedIcon />
+          }
+          if(release.releaseExtensions[i].state === "canceled"){
+              stateIcon = <ExtensionStateCanceledIcon />
           }
           return (
             <TableRow
@@ -737,7 +746,6 @@ export default class Releases extends React.Component {
                 return releaseExtension.extension
               })
 
-              console.log(release.id)
               return (<ReleaseView
                 key={release.id}
                 extensions={extensions}


### PR DESCRIPTION
* Show Canceld Statuses as a Purple Canceled Button. 
* Add a fingerprint glyph in release extension status report
* Update Admin Projects page to display info more effectively

![screen shot 2018-07-26 at 12 10 28 pm](https://user-images.githubusercontent.com/35912177/43283344-7fd64b7a-90cd-11e8-9158-3ba92ead1221.png)
![screen shot 2018-07-26 at 12 10 34 pm](https://user-images.githubusercontent.com/35912177/43283345-7fea2f5a-90cd-11e8-9d21-439c42dc8073.png)
![screen shot 2018-07-26 at 12 10 45 pm](https://user-images.githubusercontent.com/35912177/43283346-7ffffd08-90cd-11e8-8c86-5fb2f54ff921.png)
