### PR TITLE
fix: always route to releases page when feature is clicked for deploy

### DIFF
--- a/src/components/Project/Features/index.js
+++ b/src/components/Project/Features/index.js
@@ -131,7 +131,7 @@ export default class Features extends React.Component {
       },
     }).then(({data}) => {
       this.props.data.refetch()
-      this.props.history.push(this.props.match.url.replace('features', 'releases'))
+      this.props.history.push("/projects/" + this.props.match.params.slug + "/" + this.props.match.params.environment + "/releases")
     });
   }
 

--- a/src/components/Project/Secrets/index.js
+++ b/src/components/Project/Secrets/index.js
@@ -382,7 +382,6 @@ export default class Secrets extends React.Component {
         <Loading />
       )
     }
-    console.log(project)
 
     return (
       <div>

--- a/src/components/Project/Secrets/index.js
+++ b/src/components/Project/Secrets/index.js
@@ -382,6 +382,7 @@ export default class Secrets extends React.Component {
         <Loading />
       )
     }
+    console.log(project)
 
     return (
       <div>

--- a/src/components/Project/index.js
+++ b/src/components/Project/index.js
@@ -254,9 +254,14 @@ class Project extends React.Component {
           </Grid>
         </Grid>
         <Switch>
-          <Route exact path='/projects/:slug/:environment' render={(props) => (
-            <ProjectFeatures history={history} {...props} socket={socket} />
-          )}/>
+          <Route exact path='/projects/:slug/:environment' render={(props) => {
+            if(props.match.url.substr(props.match.url.length - 1) === "/"){
+              this.props.history.push(props.match.url + 'features')
+            } else {
+              this.props.history.push(props.match.url + '/features')
+            }
+            return (<div></div>)
+          }}/>
           <Route exact path='/projects/:slug/:environment/features' render={(props) => (
             <ProjectFeatures history={history} {...props} socket={socket} />
           )}/>

--- a/src/components/Project/index.js
+++ b/src/components/Project/index.js
@@ -255,11 +255,7 @@ class Project extends React.Component {
         </Grid>
         <Switch>
           <Route exact path='/projects/:slug/:environment' render={(props) => {
-            if(props.match.url.substr(props.match.url.length - 1) === "/"){
-              this.props.history.push(props.match.url + 'features')
-            } else {
-              this.props.history.push(props.match.url + '/features')
-            }
+            this.props.history.push("/projects/" + props.match.params.slug + "/" + props.match.params.environment + "/features")
             return (<div></div>)
           }}/>
           <Route exact path='/projects/:slug/:environment/features' render={(props) => (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Always route the index route to `/features`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When people click `DEPLOY` in the Features tab, sometimes the page becomes stuck and doesn't redirect to Releases. This is because the end of features page sometimes isn't `/features`. To make it consistent, we always redirect index routes to `/features` rather than re-render the `Features` component for the index route.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Dev Environment

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
