### PR TITLE
Route53 Labels

### DIFF
--- a/src/components/Project/Extensions/Route53/index.js
+++ b/src/components/Project/Extensions/Route53/index.js
@@ -197,11 +197,11 @@ export default class LoadBalancer extends React.Component {
     
     var extraOptions = []
     project.extensions.forEach(function(extension){
-      let artifact = _.find(extension.artifacts, function(a) { return "dns" in a });
+      let artifact = _.find(extension.artifacts, function(a) { return a.key === "dns" });
       if (!artifact) {
         return
       }
-      let dns = artifact["dns"]
+      let dns = artifact.value
       if(extension.extension.key.includes("loadbalancer") && extension.customConfig.type !== "internal") {
         extraOptions.push({
           key: extension.id,

--- a/src/components/Project/Extensions/Route53/index.js
+++ b/src/components/Project/Extensions/Route53/index.js
@@ -196,14 +196,18 @@ export default class LoadBalancer extends React.Component {
     }
     
     var extraOptions = []
-    project.extensions.map(function(extension){
+    project.extensions.forEach(function(extension){
+      let artifact = _.find(extension.artifacts, function(a) { return "dns" in a });
+      if (!artifact) {
+        return
+      }
+      let dns = artifact["dns"]
       if(extension.extension.key.includes("loadbalancer") && extension.customConfig.type !== "internal") {
         extraOptions.push({
           key: extension.id,
-          value: extension.extension.name,
+          value: extension.extension.name + " (" + dns + ")",
         })
       }
-      return null
     })
 
     this.form.state.extra({


### PR DESCRIPTION
* Adds labels to Route53 Load Balancer Selection
** You can now see what the FQDN/DNS name of the load balancer is before selecting.

Fixes #189 