### PR TITLE
Cleans up erronous '>' that appears in admin extension page

### DIFF
--- a/src/components/Admin/Extensions/index.js
+++ b/src/components/Admin/Extensions/index.js
@@ -640,7 +640,7 @@ export default class Extensions extends React.Component {
             <Grid item xs={2}>
               {this.getExtensionTypeGlyph(extensionGrouping[0])}     
             </Grid>                        
-          </Grid>>
+          </Grid>
         </ExpansionPanelSummary>
 
         <Divider />
@@ -666,7 +666,7 @@ export default class Extensions extends React.Component {
                 <b> { "Add Extension" } </b> 
               </Typography>             
             </Grid>            
-          </Grid>>
+          </Grid>
         </ExpansionPanelSummary>
 
         <Divider />


### PR DESCRIPTION
Cleans up erronous '>' that appears in admin extension page