### PR TITLE
Fix issue when visiting a project page with a direct link 

### DIFF
--- a/src/components/Project/Extensions/index.js
+++ b/src/components/Project/Extensions/index.js
@@ -94,7 +94,7 @@ import ExtensionNotificationIcon from '@material-ui/icons/NotificationsActive';
   options: (props) => ({
     variables: {
       slug: props.match.params.slug,
-      environmentID: props.store.app.currentEnvironment.id,
+      environmentID: props.environment.id,
     }
   })
 })

--- a/src/components/Project/Features/index.js
+++ b/src/components/Project/Features/index.js
@@ -74,7 +74,7 @@ import 'moment-timezone';
   options: (props) => ({
     variables: {
       slug: props.match.params.slug,
-      environmentID: props.store.app.currentEnvironment.id,
+      environmentID: props.environment.id,
       showDeployed: props.store.app.features.showDeployed,
     }
   })

--- a/src/components/Project/Releases/index.js
+++ b/src/components/Project/Releases/index.js
@@ -125,6 +125,12 @@ class ReleaseView extends React.Component {
     }
   }
 
+  componentWillUnmount(){
+    if (this.timerInterval !== null){
+      clearInterval(this.timerInterval)
+    }
+  }
+
   renderReleaseExtensionStatuses() { 
     const { release, extensions } = this.props;
     // filter out 'once' types

--- a/src/components/Project/Releases/index.js
+++ b/src/components/Project/Releases/index.js
@@ -383,7 +383,7 @@ class ReleaseView extends React.Component {
   options: (props) => ({
     variables: {
       slug: props.match.params.slug,
-      environmentID: props.store.app.currentEnvironment.id,
+      environmentID: props.environment.id,
     },
   })
 })

--- a/src/components/Project/Secrets/index.js
+++ b/src/components/Project/Secrets/index.js
@@ -87,6 +87,7 @@ export default class Secrets extends React.Component {
           handleOutOfBounds={this.handleOutOfBounds.bind(this)}
           history={this.props.history}
           match={this.props.match}
+          environment={this.props.environment}
           {...this.state}
           /> 
     )

--- a/src/components/Project/Secrets/paginator.js
+++ b/src/components/Project/Secrets/paginator.js
@@ -78,7 +78,7 @@ query Project($slug: String, $environmentID: String, $params: PaginatorInput! ){
     fetchPolicy: 'network-only',
     variables: {
       slug: props.match.params.slug,
-      environmentID: props.store.app.currentEnvironment.id,
+      environmentID: props.environment.id,
       params: {
         limit: props.limit || props.store.app.paginator.limit,
         page: props.page || 0,

--- a/src/components/Project/Services/index.js
+++ b/src/components/Project/Services/index.js
@@ -82,7 +82,7 @@ query Project($slug: String, $environmentID: String) {
   options: (props) => ({
     variables: {
       slug: props.match.params.slug,
-      environmentID: props.store.app.currentEnvironment.id,
+      environmentID: props.environment.id,
     }
   })
 })

--- a/src/components/Project/Settings/index.js
+++ b/src/components/Project/Settings/index.js
@@ -50,7 +50,7 @@ import Radio, {RadioGroup} from 'material-ui/Radio';
   options: (props) => ({
     variables: {
       slug: props.match.params.slug,
-      environmentID: props.store.app.currentEnvironment.id,
+      environmentID: props.environment.id,
     }
   })
 })

--- a/src/components/Project/index.js
+++ b/src/components/Project/index.js
@@ -98,7 +98,6 @@ class Project extends React.Component {
   }
 
   componentDidUpdate() {
-    console.log("project component did update")
     this.setLeftNavProjectItems(this.props)
 
     const { environment } = this.props;

--- a/src/components/Project/index.js
+++ b/src/components/Project/index.js
@@ -98,6 +98,7 @@ class Project extends React.Component {
   }
 
   componentDidUpdate() {
+    console.log("project component did update")
     this.setLeftNavProjectItems(this.props)
 
     const { environment } = this.props;
@@ -300,22 +301,22 @@ class Project extends React.Component {
         </Grid>
         <Switch>
           <Route exact path='/projects/:slug/:environment/features' render={(props) => (
-            <ProjectFeatures history={history} socket={socket} {...props} />
+            <ProjectFeatures history={history} socket={socket} {...props} environment={this.props.environment}/>
           )}/>
           <Route exact path='/projects/:slug/:environment/releases' render={(props) => (
-            <ProjectReleases socket={socket} {...props} />
+            <ProjectReleases socket={socket} {...props} environment={this.props.environment}/>
           )}/>
           <Route exact path='/projects/:slug/:environment/services' render={(props) => (
-            <ProjectServices socket={socket} {...props} />
+            <ProjectServices socket={socket} {...props} environment={this.props.environment}/>
           )}/>
           <Route exact path='/projects/:slug/:environment/secrets' render={(props) => (
-            <ProjectSecrets  history={history} socket={socket} {...props} />
+            <ProjectSecrets  history={history} socket={socket} {...props} environment={this.props.environment}/>
           )}/>
           <Route exact path='/projects/:slug/:environment/extensions' render={(props) => (
-            <ProjectExtensions socket={socket} {...props} />
+            <ProjectExtensions socket={socket} {...props} environment={this.props.environment}/>
           )}/>
           <Route exact path='/projects/:slug/:environment/settings' render={(props) => (
-            <ProjectSettings socket={socket} {...props} />
+            <ProjectSettings socket={socket} {...props} environment={this.props.environment}/>
           )}/>
 
           <Redirect strict exact from={this.props.match.path + '/'} to={`${this.props.location.pathname}features`} />          

--- a/src/components/Project/index.js
+++ b/src/components/Project/index.js
@@ -236,7 +236,7 @@ class Project extends React.Component {
   }
 
   render() {
-    const { history, socket, environment } = this.props;
+    const { environment } = this.props;
     const { loading, project, error } = this.props.data;
     if(loading){
       return <Loading/>
@@ -300,22 +300,22 @@ class Project extends React.Component {
         </Grid>
         <Switch>
           <Route exact path='/projects/:slug/:environment/features' render={(props) => (
-            <ProjectFeatures history={history} socket={socket} {...props} environment={this.props.environment}/>
+            <ProjectFeatures {...props} {...this.props}/>
           )}/>
           <Route exact path='/projects/:slug/:environment/releases' render={(props) => (
-            <ProjectReleases socket={socket} {...props} environment={this.props.environment}/>
+            <ProjectReleases {...props}  {...this.props}/>
           )}/>
           <Route exact path='/projects/:slug/:environment/services' render={(props) => (
-            <ProjectServices socket={socket} {...props} environment={this.props.environment}/>
+            <ProjectServices {...props}  {...this.props}/>
           )}/>
           <Route exact path='/projects/:slug/:environment/secrets' render={(props) => (
-            <ProjectSecrets  history={history} socket={socket} {...props} environment={this.props.environment}/>
+            <ProjectSecrets {...props}  {...this.props}/>
           )}/>
           <Route exact path='/projects/:slug/:environment/extensions' render={(props) => (
-            <ProjectExtensions socket={socket} {...props} environment={this.props.environment}/>
+            <ProjectExtensions {...props}  {...this.props}/>
           )}/>
           <Route exact path='/projects/:slug/:environment/settings' render={(props) => (
-            <ProjectSettings socket={socket} {...props} environment={this.props.environment}/>
+            <ProjectSettings {...props}  {...this.props}/>
           )}/>
 
           <Redirect strict exact from={this.props.match.path + '/'} to={`${this.props.location.pathname}features`} />          


### PR DESCRIPTION
* Fixes #303
* The issue occurs because the elements reference the app store which is not configured correctly with a direct link.
* Fixes issue with React when timer tries to set state after component has been unmounted for Project/Releases

Solution: Have the components use the `environment` prop that is handed down from the environment selector. If the app store is set, then use that. If not, then try to parse the url slug to get the current environment. If that doesn't parse or it's not an environment the project supports, then present user with the environment selection screen.