### PR TITLE
Speed Up Project View

### DIFF
--- a/src/components/Project/index.js
+++ b/src/components/Project/index.js
@@ -53,18 +53,6 @@ import Typography from 'material-ui/Typography';
            created
          }
       }
-      # releases {
-      #   entries{
-      #     id
-      #     state
-      #   }
-      # }
-      # features(params: { limit: 25}){
-      #   entries {
-      #     id
-      #     created
-      #   }
-      # }
       environments {
         id
         key
@@ -160,32 +148,18 @@ class Project extends React.Component {
         return null
     }
 
-    // count deployable features by comparing currentRelease created and feature created
-    // let deployableFeatures = project.features.entries.length
-    // if(project.currentRelease){
-    //   deployableFeatures = project.features.entries.filter(function(feature){
-    //     return (new Date(feature.created).getTime() > new Date(project.currentRelease.headFeature.created).getTime())
-    //   }).length
-    // } 
-
-    // let releasesQueued = project.releases.entries.filter(function(release){
-    //   return ["waiting", "running"].includes(release.state)
-    // }).length
-
     this.props.store.app.leftNavItems = [
         {
           key: "10",
           icon: <FeaturesIcon />,
           name: "Features",
           slug: `${props.match.url}/features`,
-          // count: deployableFeatures,
         },
         {
           key: "20",
           icon: <ReleasesIcon />,
           name: "Releases",
           slug: `${props.match.url}/releases`,
-          // count: releasesQueued,
           badgeColor: "secondary",
         },
         {

--- a/src/components/Project/index.js
+++ b/src/components/Project/index.js
@@ -53,18 +53,18 @@ import Typography from 'material-ui/Typography';
            created
          }
       }
-      releases {
-        entries{
-          id
-          state
-        }
-      }
-      features(params: { limit: 25}){
-        entries {
-          id
-          created
-        }
-      }
+      # releases {
+      #   entries{
+      #     id
+      #     state
+      #   }
+      # }
+      # features(params: { limit: 25}){
+      #   entries {
+      #     id
+      #     created
+      #   }
+      # }
       environments {
         id
         key
@@ -161,16 +161,16 @@ class Project extends React.Component {
     }
 
     // count deployable features by comparing currentRelease created and feature created
-    let deployableFeatures = project.features.entries.length
-    if(project.currentRelease){
-      deployableFeatures = project.features.entries.filter(function(feature){
-        return (new Date(feature.created).getTime() > new Date(project.currentRelease.headFeature.created).getTime())
-      }).length
-    } 
+    // let deployableFeatures = project.features.entries.length
+    // if(project.currentRelease){
+    //   deployableFeatures = project.features.entries.filter(function(feature){
+    //     return (new Date(feature.created).getTime() > new Date(project.currentRelease.headFeature.created).getTime())
+    //   }).length
+    // } 
 
-    let releasesQueued = project.releases.entries.filter(function(release){
-      return ["waiting", "running"].includes(release.state)
-    }).length
+    // let releasesQueued = project.releases.entries.filter(function(release){
+    //   return ["waiting", "running"].includes(release.state)
+    // }).length
 
     this.props.store.app.leftNavItems = [
         {
@@ -178,14 +178,14 @@ class Project extends React.Component {
           icon: <FeaturesIcon />,
           name: "Features",
           slug: `${props.match.url}/features`,
-          count: deployableFeatures,
+          // count: deployableFeatures,
         },
         {
           key: "20",
           icon: <ReleasesIcon />,
           name: "Releases",
           slug: `${props.match.url}/releases`,
-          count: releasesQueued,
+          // count: releasesQueued,
           badgeColor: "secondary",
         },
         {


### PR DESCRIPTION
Currently the project view has a top level component query which pulls a lot of unnecessary data and is very slow. This PR removes those queries and temporarily disables the feature and release # in the left nav bar.

To bring those back we will need to implement a performant count w/filtering to the releases/features paginator. Those #'s can be used to render the feature/release counts.