### PR TITLE
Release Touchups

### DIFF
--- a/src/components/Project/Features/index.js
+++ b/src/components/Project/Features/index.js
@@ -152,6 +152,11 @@ export default class Features extends React.Component {
     }).then(({data}) => {
       this.props.data.refetch()
       this.props.history.push(`/projects/${this.props.match.params.slug}/${this.props.match.params.environment}/releases`)
+    }).catch(error => {
+      let obj = JSON.parse(JSON.stringify(error))
+      if(Object.keys(obj).length > 0 && obj.constructor === Object){
+        this.props.store.app.setSnackbar({ open: true, msg: obj.graphQLErrors[0].message })
+      }
     });
   }
 

--- a/src/components/Project/Releases/index.js
+++ b/src/components/Project/Releases/index.js
@@ -205,7 +205,7 @@ class ReleaseView extends React.Component {
     let state
     switch(release.state) {  
       case "waiting":
-        state = (<CircularProgress className={styles.progress} />)
+        state = (<Chip label="QUEUED" style={{ backgroundColor: "#ff8000", color: "white" }} />)
       break;
       case "running":
         state = (<CircularProgress className={styles.progress} color="secondary" />)
@@ -249,7 +249,7 @@ class ReleaseView extends React.Component {
                 {_.has(currentRelease, 'id') && currentRelease.id === release.id && <Chip label="LATEST" className={styles.activeRelease} />}
                 <div style={{ marginTop: 40 }}>
                   <Typography variant="subheading">
-                    {this.getReadableDuration(this.state.timer)}
+                    {release.state !== "waiting" && this.getReadableDuration(this.state.timer)}
                   </Typography>
                 </div>                
               </Grid>


### PR DESCRIPTION
* Remove timer if release is in waiting state
* Add chip for 'queued' state
* Remove 'spinner' for any build not currently in progress

Needs (but does not directly depend on https://github.com/codeamp/circuit/pull/397)