### PR TITLE
Show value even if empty string in Projects/Secrets

### DIFF
--- a/src/components/Project/Secrets/paginator.js
+++ b/src/components/Project/Secrets/paginator.js
@@ -587,7 +587,7 @@ export default class SecretsPaginator extends React.Component {
               if (loading) return <div></div>
               if (error) return `Error! ${error.message}`
               let secret = data.secret
-              if(secret.value !== "" && !self.form.isDirty && !this.state.saving){
+              if(!self.form.isDirty && !this.state.saving){
                 this.form = this.initProjectSecretsForm({
                   'key': secret.key,
                   'value': secret.value,
@@ -657,12 +657,10 @@ export default class SecretsPaginator extends React.Component {
                       </Grid>
                     }
 
-                    {
-                      <EnvVarVersionHistory
-                        versions={data.secret.versions}
-                        onClickVersion={this.onClickVersion.bind(this, data.secret.versions)}
-                      />
-                    }
+                    <EnvVarVersionHistory
+                      versions={data.secret.versions}
+                      onClickVersion={this.onClickVersion.bind(this, data.secret.versions)}
+                    />
 
                     <Grid item xs={12}>
                       <Button color="primary"
@@ -712,23 +710,22 @@ export default class SecretsPaginator extends React.Component {
             </DialogActions>
           </Dialog>
 
-              <Dialog open={this.state.dialogOpen}>
-                <DialogTitle>{"Are you sure you want to delete " + secret.key + "?"}</DialogTitle>
-                <DialogContent>
-                  <DialogContentText>
-                    {"This will delete the environment variable and all its versions."}
-                  </DialogContentText>
-                </DialogContent>
-                <DialogActions>
-                  <Button onClick={()=> this.setState({ dialogOpen: false })} color="primary">
-                    Cancel
-                  </Button>
-                  <Button onClick={this.handleDeleteEnvVar.bind(this)} style={{ color: "red" }}>
-                    Confirm
-                  </Button>
-                </DialogActions>
-              </Dialog>
-          {/* } */}
+          <Dialog open={this.state.dialogOpen}>
+            <DialogTitle>{"Are you sure you want to delete " + secret.key + "?"}</DialogTitle>
+            <DialogContent>
+              <DialogContentText>
+                {"This will delete the environment variable and all its versions."}
+              </DialogContentText>
+            </DialogContent>
+            <DialogActions>
+              <Button onClick={()=> this.setState({ dialogOpen: false })} color="primary">
+                Cancel
+              </Button>
+              <Button onClick={this.handleDeleteEnvVar.bind(this)} style={{ color: "red" }}>
+                Confirm
+              </Button>
+            </DialogActions>
+          </Dialog>
         </div> )
         }}
         </Query>


### PR DESCRIPTION
Currently, we do not offer a way for users to change the value of a secret if the secret's value is empty. This is what we show:
![screen shot 2019-02-11 at 12 27 47 pm](https://user-images.githubusercontent.com/3188413/52591311-7afc3880-2df8-11e9-85cd-4629ba5e0262.png)


We should still show the value-related component even if the secret value is an empty string. The rationale being:

although we should not allow empty strings to be submitted to the API, there isn't any consequence to show an empty value and associated operations to the user. We should allow the user to delete the secret even when the value is empty, for instance