### PR TITLE
remove out of date github status extension text

### DIFF
--- a/src/components/Project/Extensions/GithubStatus/index.js
+++ b/src/components/Project/Extensions/GithubStatus/index.js
@@ -6,11 +6,13 @@ export default class GithubStatus extends React.Component {
         return (
            <div>
                <Typography>
-                1. Create a Personal Access Token <a href="https://github.com/settings/tokens/new"> here </a> <br/>
-                2. Enable SSO by clicking on the SSO button located at the top right of the generated PAT entry (located <a href="https://github.com/settings/tokens"> here </a>). <br/>
-                3. Copy and save the generated token string as a project Environment Variable. Also create a project Environment Variable for your Github user. <br/>
-                4. Select the created environment variables in the Config dropdown above for the respective inputs. <br/>
-                5. Click SAVE below and we'll verify that you followed the previous 2 steps.
+                The default Github Status timeout is 300 seconds. <br/>
+                If your github status process takes over the set timeout, you should increase the timeout. <br/>
+
+                To increase the timeout: <br/>
+                1. Add a new environment variable in the secrets section with a new timeout value (i.e. GITHUB_STATUS_TIMEOUT=500) <br/>
+                2. If already installed, delete the existing Github Status extension <br/>
+                3. Install Github Status, mapping TIMEOUT_SECONDS => "CUSTOM_STATUS_TIMEOUT_ENV_VAR" from the drop down <br/>
                </Typography>
             </div>
         )


### PR DESCRIPTION
remove out of date github status extension text and replace with something useful. fixes #341