### PR TITLE
remove websockets checkbox from kong ingress extension

### DIFF
--- a/src/components/Project/Extensions/IngressKong/index.js
+++ b/src/components/Project/Extensions/IngressKong/index.js
@@ -5,7 +5,6 @@ import Button from 'material-ui/Button';
 import IconButton from 'material-ui/IconButton';
 import CloseIcon from '@material-ui/icons/Close';
 import SelectField from 'components/Form/select-field';
-import CheckboxField from 'components/Form/checkbox-field';
 import RadioField from 'components/Form/radio-field';
 import Loading from 'components/Utils/Loading';
 import validatorjs from 'validatorjs';

--- a/src/components/Project/Extensions/IngressKong/index.js
+++ b/src/components/Project/Extensions/IngressKong/index.js
@@ -242,7 +242,6 @@ export default class Ingress extends React.Component {
       'type',
       'protocol',
       'subdomain',
-      'enable_websockets',
       'upstream_routes',
       'upstream_routes[].domains',
       'upstream_routes[].domains[].subdomain',
@@ -260,7 +259,6 @@ export default class Ingress extends React.Component {
         'ingress': "INGRESS",
         'service': "SERVICE",
         'protocol': "PROTOCOL",
-        'enable_websockets': 'ENABLE WEBSOCKETS',
         'type': "TYPE",
         'upstream_routes': "UPSTREAM ROUTES",
         'upstream_routes[].domains[].subdomain': 'SUBDOMAIN',
@@ -269,9 +267,7 @@ export default class Ingress extends React.Component {
         'upstream_routes[].methods': "METHODS",
     }
     const initials = {}
-    const types = {
-      "enable_websockets": 'checkbox'
-    }
+    const types = {}
 
     const extra = {
         'ingress': this.state.ingressControllers,
@@ -361,9 +357,6 @@ export default class Ingress extends React.Component {
                       <Grid container spacing={24} direction={'row'}>
                         <Grid item xs={8}>
                           <SelectField fullWidth={true} field={this.form.$('ingress')} />
-                        </Grid>
-                        <Grid item xs={4}>
-                          <CheckboxField field={this.form.$('enable_websockets')} />
                         </Grid>
                         <Grid item xs={12}>
                           {this.form.$('upstream_routes').map(function(route){


### PR DESCRIPTION
Currently the websockets checkbox in the kong ingress extension does not have a functional purpose.