### PR TITLE
Fix the bug of failed release time display 

### DIFF
--- a/src/components/Project/Releases/index.js
+++ b/src/components/Project/Releases/index.js
@@ -60,7 +60,7 @@ class ReleaseView extends React.Component {
     let timer =  0
     let startTimer = false
 
-    if(releaseFinished.getTime() > 0 && this.props.release.state === "complete") {
+    if(releaseFinished.getTime() > 0 && ["complete", "failed", "canceled"].includes(this.props.release.state)) {
       currentTime = new Date(this.props.release.finished)
       diff = currentTime - new Date(this.props.release.started).getTime();
       timer = Math.floor(diff/1000)
@@ -895,7 +895,7 @@ export default class Releases extends React.Component {
     if(loading){
       return (<Loading />)
     }
-    
+
     let latestSuccessfulRelease = this.getLatestSuccessfulRelease()
     
     return (


### PR DESCRIPTION
How to reproduce:
1. Try to release one feature that will fail
2. When it fails, you can still see the time it took before it fails
3. But when you refresh the page, the time is gone, displaying `0`

Now is fixed.
![Screen Shot 2019-07-12 at 2 30 28 PM](https://user-images.githubusercontent.com/28639778/61163675-72ea1700-a4c4-11e9-8501-25519daf4c1d.png)
