### PR TITLE
Fix secret version histroy selection problem #309

### DIFF
--- a/src/components/Admin/Secrets/index.js
+++ b/src/components/Admin/Secrets/index.js
@@ -253,6 +253,7 @@ export default class Secrets extends React.Component {
 
   onClickVersion(versionIdx) {
     this.form.$('value').set(this.props.data.secrets.entries[this.form.values()['index']].versions[versionIdx].value)
+    this.setState({ formValue: this.form.values()['value'] })
   }
 
   onError(form){
@@ -298,7 +299,7 @@ export default class Secrets extends React.Component {
 
   openDrawer(){
     this.form.showErrors(false)
-    this.setState({ addEnvVarMenuOpen: false, drawerOpen: true, saving: false });
+    this.setState({ addEnvVarMenuOpen: false, drawerOpen: true, saving: false, formValue: this.form.values()['value'] });
   }
 
   closeDrawer(force = false){
@@ -330,6 +331,7 @@ export default class Secrets extends React.Component {
 
   onFileEditorChange(newValue) {
     this.form.$('value').set(newValue)
+    this.setState({ formValue: newValue })
   }
 
   render() {
@@ -472,7 +474,7 @@ export default class Secrets extends React.Component {
                         mode="yaml"
                         theme="github"
                         onChange={this.onFileEditorChange.bind(this)}
-                        value={this.form.values()['value']}
+                        value={this.state.formValue}
                         name="file-content"
                         editorProps={{$blockScrolling: true}}
                         focus={true}

--- a/src/components/Project/Secrets/paginator.js
+++ b/src/components/Project/Secrets/paginator.js
@@ -342,11 +342,13 @@ export default class SecretsPaginator extends React.Component {
 
   onFileEditorChange(newValue) {
     this.form.$('value').set(newValue)
+    this.setState({ formValue: newValue })
   }
 
 
   onClickVersion(versions, idx) {
     this.form.$('value').set(versions[idx].value)
+    this.setState({ formValue: this.form.values()['value'] })
   }
 
   onError(form){
@@ -647,7 +649,7 @@ export default class SecretsPaginator extends React.Component {
                             mode="yaml"
                             theme="github"
                             onChange={this.onFileEditorChange.bind(this)}
-                            value={this.form.values()['value']}
+                            value={this.state.values || this.form.values()['value']}
                             name="file-content"
                             editorProps={{$blockScrolling: true}}
                             focus={true}

--- a/src/components/Utils/EnvVarVersionHistory/index.js
+++ b/src/components/Utils/EnvVarVersionHistory/index.js
@@ -46,6 +46,7 @@ export default class EnvVarVersionHistory extends React.Component {
               {versions.map(function(secret, idx){
                   return (
                     <TableRow
+                      className={styles.tableRow}
                       hover
                       tabIndex={-1}
                       onClick={() => onClickVersion(idx)}

--- a/src/components/Utils/EnvVarVersionHistory/style.module.css
+++ b/src/components/Utils/EnvVarVersionHistory/style.module.css
@@ -5,3 +5,7 @@
 .root {
     overflow: auto;
 }
+
+.tableRow {
+    cursor: pointer;
+}


### PR DESCRIPTION
Fix #309. Now both history version selection should work in both `admin secrets` and `project secrets`. Also change table row to cursor so make more sense to click.

Set the form value to the state, so that the page is re-rendered when value changed.

A little tricky in the `Secrets/paginator.js`. Part of render return is wrapped in Query, but we cannot change state in query. I adopt a method using `||`. The first time we opened drawer, `this.state.formValue` will be undefined and will rendered `this.form.values()['value']`. But after that, these two values will sync.
