### PR TITLE
Clear search bar when navigate to another page

### DIFF
--- a/src/components/TopNav/index.js
+++ b/src/components/TopNav/index.js
@@ -161,7 +161,7 @@ class TopNav extends React.Component {
       this.setState({ projects: projects })
     }
 
-    if (nextProps.location.pathname != this.props.location.pathname) {
+    if (nextProps.location.pathname !== this.props.location.pathname) {
       this.setState({ projectQuery: "" })
     }
   }

--- a/src/components/TopNav/index.js
+++ b/src/components/TopNav/index.js
@@ -160,6 +160,10 @@ class TopNav extends React.Component {
       })
       this.setState({ projects: projects })
     }
+
+    if (nextProps.location.pathname != this.props.location.pathname) {
+      this.setState({ projectQuery: "" })
+    }
   }
 
   onMouseEnter(index){


### PR DESCRIPTION
Fix #289. When path changes, clear the search bar.