### PR TITLE
Add notification of creating service error

### DIFF
--- a/src/components/Project/Services/content.js
+++ b/src/components/Project/Services/content.js
@@ -494,7 +494,7 @@ export default class ServicesContent extends React.Component {
   }
 
   handleFormChanged() {
-    this.setState({userHasUnsavedChanges: true})
+    this.setState({ userHasUnsavedChanges: true, saving: false })
   }
 
   handleDeleteService() {
@@ -541,13 +541,23 @@ export default class ServicesContent extends React.Component {
       }).then(({data}) => {
         this.props.data.refetch()
         this.closeDrawer(true)
-      })
+      }).catch(error => {
+        let obj = JSON.parse(JSON.stringify(error))
+        if(Object.keys(obj).length > 0 && obj.constructor === Object){
+          this.props.store.app.setSnackbar({ open: true, msg: "Error: " + obj.graphQLErrors[0].message })
+        }
+      });
     } else {
       this.props.createService({
         variables: form.values(),
       }).then(({data}) => {
         this.props.data.refetch()
         this.closeDrawer(true)
+      }).catch(error => {
+        let obj = JSON.parse(JSON.stringify(error))
+        if(Object.keys(obj).length > 0 && obj.constructor === Object){
+          this.props.store.app.setSnackbar({ open: true, msg: "Error: " + obj.graphQLErrors[0].message })
+        }
       });
     }
   }


### PR DESCRIPTION
Fix #302. Pop up a snack bar if error of creating service. Format the error message. Also allow users to re-click `SAVE` button if they edit the form.

![Screen Shot 2019-07-18 at 3 45 20 PM](https://user-images.githubusercontent.com/28639778/61497535-9e617b80-a974-11e9-964c-6792bb5b2411.png)
