### PR TITLE
Reset feature list when navigate away page

### DIFF
--- a/src/components/Project/Features/index.js
+++ b/src/components/Project/Features/index.js
@@ -118,6 +118,9 @@ export default class Features extends React.Component {
     // Bind socketHandler to THIS so when we pass it to the socket
     // lib and refernece 'this' its still 'us'
     this.socketHandler = this.socketHandler.bind(this);
+
+    // reset feature list when component construct
+    this.props.store.app.setFeatures({ showDeployed: this.state.showDeployed })
   }
 
   handleChange = panel => (event, expanded) => {


### PR DESCRIPTION
**How to reproduce bug:**

1. Go to the 'features' page and have all your features deployed, when filtering by 'new' commits you shouldn't see anything, which is fine

2. Select the 'all' view to see all the features, deployed or not, that works too

3. Then if you navigate away and come back, the selector is set to 'new'
but you get the view for 'all'

**What I did:**
Call `setFeature` function when component consturcts